### PR TITLE
Fix major issues in the GUI docking system.

### DIFF
--- a/src/dock_manager.c
+++ b/src/dock_manager.c
@@ -885,8 +885,14 @@ BOOL DockManager_LoadLayout(DockManager* pMgr, const wchar_t* filePath) {
 							pFltWnd->dockSite->rootGroup = NULL;
                         }
 						// Clear the temporary pane and content that FloatingWindow_Create made
-						List_Clear(pFltWnd->dockSite->allPanes, (ListItemFreeFunc)DockPane_Destroy);
-						List_Clear(pFltWnd->dockSite->allContents, NULL); // This list doesn't own the content structs
+						while (List_GetCount(pFltWnd->dockSite->allPanes) > 0) {
+							DockPane* pane = (DockPane*)List_GetAt(pFltWnd->dockSite->allPanes, 0);
+							DockPane_Destroy(pane);
+							List_RemoveAt(pFltWnd->dockSite->allPanes, 0);
+						}
+						while (List_GetCount(pFltWnd->dockSite->allContents) > 0) {
+							List_RemoveAt(pFltWnd->dockSite->allContents, 0);
+						}
 
                         pFltWnd->dockSite->rootGroup = LoadDockGroupRecursive(f, pMgr, pFltWnd->dockSite, NULL, 2); // Load actual layout
 


### PR DESCRIPTION
This commit addresses several critical architectural bugs in the docking system that caused incorrect layout behavior, especially after loading a saved layout. It also fixes a build break introduced in a previous commit.

The key fixes are:
- Corrected `DockSite` association during layout loading. Panes and content in floating windows are now correctly associated with their own site instead of the main window's site. This fixes the primary visual bug where all panels would appear in the top-left corner.
- Implemented robust tab drag-and-drop. Tabs can now be dragged between different panes, including panes in separate floating windows.
- Implemented the removal of empty panes. When the last tab is dragged out of a pane, the pane is now correctly removed, and the layout collapses to fill the space.
- Improved the robustness of the layout file parser, making it resilient to variations in formatting.
- Fixed a build error related to clearing lists by replacing a call to a non-existent `List_Clear` function with a manual loop.