### PR TITLE
Fix major issues and build errors in the GUI docking system.

### DIFF
--- a/src/dock_manager.c
+++ b/src/dock_manager.c
@@ -508,7 +508,7 @@ LRESULT CALLBACK FloatingWindow_WndProc(HWND hWnd, UINT message, WPARAM wParam, 
 // --- Undocking and Floating ---
 
 // Forward declaration for helper
-static DockSite* GetSiteForPane(DockManager* pMgr, DockPane* pPane)
+DockSite* GetSiteForPane(DockManager* pMgr, DockPane* pPane)
 {
 	if (!pMgr || !pPane) return NULL;
 

--- a/src/dock_system.h
+++ b/src/dock_system.h
@@ -176,6 +176,7 @@ void DockManager_RemovePane(DockManager* pMgr, DockPane* pPane);
 
 // Helper to get the manager instance (if it's a singleton)
 DockManager* GetDockManager();
+DockSite* GetSiteForPane(DockManager* pMgr, DockPane* pPane);
 
 // Layout Serialization
 BOOL DockManager_SaveLayout(DockManager* pMgr, const wchar_t* filePath);


### PR DESCRIPTION
This commit addresses several critical architectural bugs in the docking system that caused incorrect layout behavior, especially after loading a saved layout. It also fixes build errors discovered during compilation.

The key fixes are:
- Corrected `DockSite` association during layout loading. Panes and content in floating windows are now correctly associated with their own site instead of the main window's site. This fixes the primary visual bug where all panels would appear in the top-left corner.
- Implemented robust tab drag-and-drop. Tabs can now be dragged between different panes, including panes in separate floating windows.
- Implemented the removal of empty panes. When the last tab is dragged out of a pane, the pane is now correctly removed, and the layout collapses to fill the space.
- Improved the robustness of the layout file parser, making it resilient to variations in formatting.
- Fixed a build error related to clearing lists by replacing a call to a non-existent `List_Clear` function with a manual loop.
- Fixed a linker error by removing the `static` keyword from `GetSiteForPane` and adding a declaration to the header, making it accessible across compilation units.