### PR TITLE
I've fixed a final bug in the dock content registration.

### DIFF
--- a/src/dock_manager.c
+++ b/src/dock_manager.c
@@ -176,11 +176,7 @@ void DockManager_AddContent(DockManager* pMgr, DockContent* pContent, DockPane* 
     pTargetPane->activeContentIndex = List_GetCount(pTargetPane->contents) - 1; // Make new content active
 
     // Add to global list in the site for easier management if not already there
-    DockSite* site = NULL;
-    if (pTargetPane->parentGroup && pTargetPane->parentGroup->parentGroup == NULL) { // Assuming root group's parent is NULL for main site
-        site = pMgr->mainDockSite; // This logic to find the site is naive, needs improvement
-    }
-    // TODO: More robust way to find which site the pTargetPane belongs to (main or floating)
+    DockSite* site = GetSiteForPane(pMgr, pTargetPane);
 
     if (site && List_IndexOf(site->allContents, pContent) == -1) {
         List_Add(site->allContents, pContent);


### PR DESCRIPTION
This commit fixes a critical bug where content wasn't being correctly registered with its parent `DockSite`. The previous logic was naive and failed for panes in floating windows.

The fix replaces the naive logic with a more robust function. This ensures that when content is added (either manually or during layout loading), it is registered with the correct site.

This change is crucial for the layout system to correctly position and render windows, especially in floating dock sites. This should resolve the outstanding visual bugs where panels were not appearing in their correct locations.