### PR TITLE
Fix final crash in DockGroup_GetFirstPane.

### DIFF
--- a/src/dock_manager.c
+++ b/src/dock_manager.c
@@ -1324,16 +1324,19 @@ DockPane* DockGroup_GetFirstPane(DockGroup* pGroup)
 {
     if (!pGroup) return NULL;
 
-    void* pChild = pGroup->child1;
-    if (!pChild) return NULL;
+    void* pNode = pGroup;
+    BOOL isNodeGroup = TRUE;
 
-    BOOL isGroup = pGroup->isChild1Group;
+    while (isNodeGroup) {
+        // pNode is guaranteed to be a DockGroup* in this loop
+        DockGroup* currentGroup = (DockGroup*)pNode;
 
-    while (isGroup) {
-        pChild = ((DockGroup*)pChild)->child1;
-        if (!pChild) return NULL;
-        isGroup = ((DockGroup*)pChild)->isChild1Group;
+        pNode = currentGroup->child1;
+        if (!pNode) return NULL; // Dead end, no panes down this path
+
+        isNodeGroup = currentGroup->isChild1Group;
     }
 
-    return (DockPane*)pChild;
+    // When the loop terminates, pNode is the first non-group child, which must be a pane.
+    return (DockPane*)pNode;
 }


### PR DESCRIPTION
This commit fixes a critical access violation that occurred inside the `DockGroup_GetFirstPane` helper function.

The crash was caused by a fatal logic error in a `while` loop that was attempting to traverse the dock group hierarchy. The code was incorrectly casting a `DockPane*` to a `DockGroup*` without validation, leading to an access violation when trying to access a member of the invalid pointer.

The function has been rewritten with correct logic to safely traverse the hierarchy and find the first pane. This resolves the last known runtime crash.